### PR TITLE
feature/ads-478 add a11y statement to resources

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,7 +5,11 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Web site created using create-react-app" data-react-helmet="true" />
+    <meta
+      name="description"
+      content="Anatomy, Boston Scientific's global design system, creates consistent and accessible digital experiences that empower our users' problem-solving."
+      data-react-helmet="true"
+    />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/favicon/apple-touch-icon.png" />
     <!--
       manifest.json provides metadata used when your web app is installed on a

--- a/src/docs/pages/resources/Resources.tsx
+++ b/src/docs/pages/resources/Resources.tsx
@@ -46,6 +46,10 @@ const Resources = (): JSX.Element => {
         to: basePath + '/about-anatomy'
       },
       {
+        text: 'Accessibility statement',
+        to: basePath + '/accessibility-statement'
+      },
+      {
         text: 'Community',
         to: basePath + '/community'
       },

--- a/src/docs/shared/components/LandingPage.tsx
+++ b/src/docs/shared/components/LandingPage.tsx
@@ -45,7 +45,7 @@ const LandingPage = (props: Props): JSX.Element => {
       <div className="docs-body-minimal">
         <main id="mainContent">
           <h1>{props.heading}</h1>
-          <CardGroup cardLayout="threeUp" className="bsds-mt-6x">
+          <CardGroup cardLayout="twoUp" className="bsds-mt-4x">
             {groupedItems.map((group) => (
               <Fragment key={`group${group[0].id}`}>
                 {group

--- a/src/docs/shared/components/NotFound.tsx
+++ b/src/docs/shared/components/NotFound.tsx
@@ -6,7 +6,7 @@ const NotFound = (): JSX.Element => {
     <Layout>
       <div className="docs-body-minimal">
         <main id="mainContent">
-          <h1>Oops!</h1>
+          <h1>Page not found</h1>
           <p>Looks like this page doesn&apos;t exist.</p>
           <Link to="/">Go to the home page</Link>
         </main>


### PR DESCRIPTION
Snuck in a couple of changes in this PR:
- add a11y statement page to resources section
- swap landing pages to 2-up cards and reduce top margin
- change h1 text on 404 page to align with content guidelines
- update default meta data so landing pages and 404s aren't showing "web site created with create-react-app" in our search results page